### PR TITLE
Add support for ppxlib 0.23.0

### DIFF
--- a/metaquot/metaquot.ml
+++ b/metaquot/metaquot.ml
@@ -93,8 +93,12 @@ let quote_of_path (path : Path.t) : Ppxlib.expression =
   let name =
     match Untypeast.lident_of_path path with
     | Lident name | Ldot (Lident "Asttypes", name) -> name
-    | Ldot (Lident "Location", "t") -> "location"
-    | Ldot (Lident "Longident", "t") -> "longident"
+    | Ldot (Lident "Location", "t") (* ppxlib < 0.23.0 *)
+    | Ldot (Ldot (Lident "Astlib__", "Location"), "t") -> (* ppxlib >= 0.23.0 *)
+        "location"
+    | Ldot (Lident "Longident", "t") (* ppxlib < 0.23.0 *)
+    | Ldot (Ldot (Lident "Astlib__", "Longident"), "t") -> (* ppxlib >= 0.23.0 *)
+        "longident"
     | lident ->
         failwith (Format.asprintf "quote_of_path: %s"
           (String.concat "." (Longident.flatten lident))) in

--- a/ppx/dune
+++ b/ppx/dune
@@ -5,5 +5,4 @@
   (ppx_runtime_libraries compiler-libs)
 ; -warning 40: Constructor or label name used out of scope. (OCaml <=4.06.0)
   (flags -w -40)
-  (libraries ocaml-migrate-parsetree compiler-libs metapp stdcompat
-    metaquot))
+  (libraries compiler-libs metapp stdcompat metaquot))

--- a/tests/for/for_test.ml
+++ b/tests/for/for_test.ml
@@ -6,5 +6,5 @@ let () =
   | { pstr_desc = Pstr_type (Recursive, [
         { ptype_name = { txt = "t1"; _ }; _};
         { ptype_name = { txt = "t2"; _ }; _};
-        { ptype_name = { txt = "t3"; _ }; _}])} -> ()
+        { ptype_name = { txt = "t3"; _ }; _}]); _} -> ()
   | _ -> assert false


### PR DESCRIPTION
ppxlib will come without OMP starting with ppxlib.0.23.0.
A few changes were needed to match the new module location with what metaquot expects.

cc @pitag-ha