### PR TITLE
Add support for OCaml 4.13

### DIFF
--- a/metaquot/metaquot.ml
+++ b/metaquot/metaquot.ml
@@ -247,7 +247,7 @@ let quote_of_declaration (prefix : Longident.t) (name : string)
           (Metapp.apply
             (quote_of_type_expr (Option.get declaration.type_manifest))
             [Metapp.Exp.var "x"])]
-    | Type_variant ctors ->
+    | Type_variant (ctors, _) ->
         List.map (case_of_ctor prefix) ctors
     | Type_record (labels, _) ->
         [quote_of_record prefix labels]

--- a/metaquot/metaquot.ml
+++ b/metaquot/metaquot.ml
@@ -93,8 +93,12 @@ let quote_of_path (path : Path.t) : Ppxlib.expression =
   let name =
     match Untypeast.lident_of_path path with
     | Lident name | Ldot (Lident "Asttypes", name) -> name
-    | Ldot (Lident "Location", "t") -> "location"
-    | Ldot (Lident "Longident", "t") -> "longident"
+    | Ldot (Lident "Location", "t") (* ppxlib < 0.23.0 *)
+    | Ldot (Ldot (Lident "Astlib__", "Location"), "t") -> (* ppxlib >= 0.23.0 *)
+        "location"
+    | Ldot (Lident "Longident", "t") (* ppxlib < 0.23.0 *)
+    | Ldot (Ldot (Lident "Astlib__", "Longident"), "t") -> (* ppxlib >= 0.23.0 *)
+        "longident"
     | lident ->
         failwith (Format.asprintf "quote_of_path: %s"
           (String.concat "." (Longident.flatten lident))) in

--- a/ppx/dune
+++ b/ppx/dune
@@ -5,5 +5,4 @@
   (ppx_runtime_libraries compiler-libs)
 ; -warning 40: Constructor or label name used out of scope. (OCaml <=4.06.0)
   (flags -w -40)
-  (libraries ocaml-migrate-parsetree compiler-libs metapp stdcompat
-    metaquot))
+  (libraries compiler-libs metapp stdcompat metaquot))

--- a/tests/for/for_test.ml
+++ b/tests/for/for_test.ml
@@ -6,5 +6,5 @@ let () =
   | { pstr_desc = Pstr_type (Recursive, [
         { ptype_name = { txt = "t1"; _ }; _};
         { ptype_name = { txt = "t2"; _ }; _};
-        { ptype_name = { txt = "t3"; _ }; _}])} -> ()
+        { ptype_name = { txt = "t3"; _ }; _}]); _} -> ()
   | _ -> assert false


### PR DESCRIPTION
This PR comes one top of https://github.com/thierry-martinez/metaquot/pull/2 as ppxlib.0.23.0 will also come with the OCaml 4.13 support.
There was one extra change that was needed for OCaml 4.13. However currently this makes it break with OCaml 4.12 and below as the type of `Type_variant` changed.
I tried to use `[%meta if Sys.ocaml_version >= "4.13.0" then [%p? Type_variant (ctors, _)] else [%p? Type_variant ctors]]` instead, however this broke the compilation:
```
File "_none_", line 1:
Error: execution of module initializers in the shared library failed: (Invalid_argument "index out of bounds")
```

Feel free to modify this PR

cc @pitag-ha